### PR TITLE
Add optional environment variable which allow directory export to be read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The exports file contains these parameters:
 
 `*(rw,fsid=0,async,no_subtree_check,no_auth_nlm,insecure,no_root_squash)`
 
+Adding `-e READ_ONLY=true` will cause the exports file to contain `ro` instead of `rw`, allowing only read access by the clients. 
+
 Note that the `showmount` command won't work against the server as rpcbind isn't running.
 
 ### RancherOS
@@ -81,7 +83,7 @@ rpc.nfsd: Created AF_INET6 TCP socket.
 Exporting File System...
 exporting *:/nfsshare
 Starting Mountd in the background...
-```
+``` 
 
 ### Dockerfile
 

--- a/confd/tmpl/exports.tmpl
+++ b/confd/tmpl/exports.tmpl
@@ -1,1 +1,1 @@
-{{getenv "SHARED_DIRECTORY"}} *(rw,fsid=0,async,no_subtree_check,no_auth_nlm,insecure,no_root_squash)
+{{getenv "SHARED_DIRECTORY"}} *({{getenv "READ_ONLY"}}ro{{else}}rw{{end}},fsid=0,async,no_subtree_check,no_auth_nlm,insecure,no_root_squash)

--- a/confd/tmpl/exports.tmpl
+++ b/confd/tmpl/exports.tmpl
@@ -1,1 +1,1 @@
-{{getenv "SHARED_DIRECTORY"}} *({{getenv "READ_ONLY"}}ro{{else}}rw{{end}},fsid=0,async,no_subtree_check,no_auth_nlm,insecure,no_root_squash)
+{{getenv "SHARED_DIRECTORY"}} *({{if getenv "READ_ONLY"}}ro{{else}}rw{{end}},fsid=0,async,no_subtree_check,no_auth_nlm,insecure,no_root_squash)

--- a/confd/toml/exports.toml
+++ b/confd/toml/exports.toml
@@ -4,4 +4,5 @@ dest = "/etc/exports"
 mode = "0644"
 keys = [
     "SHARED_DIRECTORY",
+    "READ_ONLY"
 ]


### PR DESCRIPTION
In case you are interested in pulling this into your repo:
-e READ_ONLY=true in docker run command will change /etc/exports parameter rw to ro
Thanks for the nice image.