### PR TITLE
Changed source image to library alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hypriot/rpi-alpine:latest
+FROM alpine:latest
 LABEL maintainer "Steven Iveson <steve@iveson.eu>"
 LABEL source "https://github.com/sjiveson/nfs-server-alpine"
 LABEL branch "arm"


### PR DESCRIPTION
This changes the source image from hypriot/rpi-alpine which is a bit dated over to Docker's Alpine library image. Builds and tests clean:

docker build:
```
pi@node-01:~ $ docker build -t alpine_library_arm .
Sending build context to Docker daemon  50.31MB
Step 1/14 : FROM alpine:latest
 ---> 889c6315e8d7
Step 2/14 : LABEL maintainer "Steven Iveson <steve@iveson.eu>"
 ---> Running in 6f7631883773
 ---> 52fd75c23b6e
Removing intermediate container 6f7631883773
Step 3/14 : LABEL source "https://github.com/sjiveson/nfs-server-alpine"
 ---> Running in ac5b811e37d5
 ---> 4f0bbd0a12fe
Removing intermediate container ac5b811e37d5
Step 4/14 : LABEL branch "arm"
 ---> Running in 060cef24c92e
 ---> c71cea4c8edd
-- truncated ---
Step 14/14 : ENTRYPOINT /usr/bin/nfsd.sh
 ---> Running in 39c254a609c7
 ---> 5710390ec16e
Removing intermediate container 39c254a609c7
Successfully built 5710390ec16e
Successfully tagged alpine_library_arm:latest
```

docker run:
```
pi@node-01:~ $ docker run --rm -it --name nfs --privileged -v /storage:/nfsshare -p 2049:2049 -e SHARED_DIRECTORY=/nfsshare alpine_library_arm
Starting Confd population of files...
confd 0.15.0-dev (Git SHA: 59001ca, Go Version: go1.9.1)
2018-01-19T16:01:01Z c3367d4aae55 /usr/bin/confd[13]: INFO Backend set to env
2018-01-19T16:01:01Z c3367d4aae55 /usr/bin/confd[13]: INFO Starting confd
2018-01-19T16:01:01Z c3367d4aae55 /usr/bin/confd[13]: INFO Backend source(s) set to
2018-01-19T16:01:01Z c3367d4aae55 /usr/bin/confd[13]: INFO /etc/exports has md5sum 4f1bb7b2412ce5952ecb5ec22d8ed99d should be 92cc8fa446eef0e167648be03aba09e5
2018-01-19T16:01:01Z c3367d4aae55 /usr/bin/confd[13]: INFO Target config /etc/exports out of sync
2018-01-19T16:01:01Z c3367d4aae55 /usr/bin/confd[13]: INFO Target config /etc/exports has been updated

Displaying /etc/exports contents...
/nfsshare *(rw,fsid=0,async,no_subtree_check,no_auth_nlm,insecure,no_root_squash)

Starting NFS in the background...
rpc.nfsd: knfsd is currently down
rpc.nfsd: Writing version string to kernel: -2 -3 +4
rpc.nfsd: Created AF_INET TCP socket.

rpc.nfsd: Created AF_INET6 TCP socket.
Exporting File System...
exporting *:/nfsshare
Starting Mountd in the background...
^CSIGTERM caught, terminating NFS process(es)...
```

Mounted:
```
pi@node-02:~ $ sudo mount -v 172.12.0.1:/ /home/pi/lol
mount.nfs: timeout set for Fri Jan 19 16:05:50 2018
mount.nfs: trying text-based options 'vers=4.2,addr=172.12.0.1,clientaddr=172.14.32.87'
mount.nfs: mount(2): Invalid argument
mount.nfs: trying text-based options 'vers=4.1,addr=172.12.0.1,clientaddr=172.14.32.87'
mount.nfs: mount(2): Invalid argument
mount.nfs: trying text-based options 'vers=4.0,addr=172.12.0.1,clientaddr=172.14.32.87'
pi@node-02:~ $ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        30G  2.4G   26G   9% /
devtmpfs        460M     0  460M   0% /dev
tmpfs           464M     0  464M   0% /dev/shm
tmpfs           464M   13M  452M   3% /run
tmpfs           5.0M  4.0K  5.0M   1% /run/lock
tmpfs           464M     0  464M   0% /sys/fs/cgroup
/dev/mmcblk0p1   41M   21M   21M  51% /boot
tmpfs            93M     0   93M   0% /run/user/1000
172.12.0.1:/    116G   18M  114G   1% /home/pi/lol
```