### PR TITLE
Add more flexible options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apk add --no-cache --update --verbose nfs-utils bash iproute2 && \
     echo "rpc_pipefs    /var/lib/nfs/rpc_pipefs rpc_pipefs      defaults        0       0" >> /etc/fstab && \
     echo "nfsd  /proc/fs/nfsd   nfsd    defaults        0       0" >> /etc/fstab
 
-COPY exports /etc/
 COPY nfsd.sh /usr/bin/nfsd.sh
 COPY .bashrc /root/.bashrc
 

--- a/exports
+++ b/exports
@@ -1,1 +1,0 @@
-{{SHARED_DIRECTORY}} {{PERMITTED}}({{READ_ONLY}},fsid=0,{{SYNC}},no_subtree_check,no_auth_nlm,insecure,no_root_squash)

--- a/nfsd.sh
+++ b/nfsd.sh
@@ -19,63 +19,77 @@ stop()
   exit
 }
 
-# Check if the SHARED_DIRECTORY variable is empty
-if [ -z "${SHARED_DIRECTORY}" ]; then
-  echo "The SHARED_DIRECTORY environment variable is unset or null, exiting..."
-  exit 1
-else
-  echo "Writing SHARED_DIRECTORY to /etc/exports file"
-  /bin/sed -i "s@{{SHARED_DIRECTORY}}@${SHARED_DIRECTORY}@g" /etc/exports
-fi
+# How much do we need these checks?
+## Check if the PERMITTED variable is empty
+#if [ -z "${PERMITTED}" ]; then
+#  echo "The PERMITTED environment variable is unset or null, defaulting to '*'."
+#  echo "This means any client can mount."
+#  /bin/sed -i "s/{{PERMITTED}}/*/g" /etc/exports
+#else
+#  echo "The PERMITTED environment variable is set."
+#  echo "The permitted clients are: ${PERMITTED}."
+#  /bin/sed -i "s/{{PERMITTED}}/"${PERMITTED}"/g" /etc/exports
+#fi
+#
+## Check if the READ_ONLY variable is set (rather than a null string) using parameter expansion
+#if [ -z ${READ_ONLY+y} ]; then
+#  echo "The READ_ONLY environment variable is unset or null, defaulting to 'rw'."
+#  echo "Clients have read/write access."
+#  /bin/sed -i "s/{{READ_ONLY}}/rw/g" /etc/exports
+#else
+#  echo "The READ_ONLY environment variable is set."
+#  echo "Clients will have read-only access."
+#  /bin/sed -i "s/{{READ_ONLY}}/ro/g" /etc/exports
+#fi
+#
+## Check if the SYNC variable is set (rather than a null string) using parameter expansion
+#if [ -z "${SYNC+y}" ]; then
+#  echo "The SYNC environment variable is unset or null, defaulting to 'async' mode".
+#  echo "Writes will not be immediately written to disk."
+#  /bin/sed -i "s/{{SYNC}}/async/g" /etc/exports
+#else
+#  echo "The SYNC environment variable is set, using 'sync' mode".
+#  echo "Writes will be immediately written to disk."
+#  /bin/sed -i "s/{{SYNC}}/sync/g" /etc/exports
+#fi
 
-# This is here to demonsrate how multiple directories can be shared. You
-# would need a block like this for each extra share.
-# Any additional shares MUST be subdirectories of the root directory specified
-# by SHARED_DIRECTORY.
+# Build opts string
+opts=`echo "${READ_ONLY} ${SYNC} ${FSID} ${SUBTREE_CHECK} ${ROOT_SQUASH}" | tr -s ' ' | tr ' ' ','`
 
-# Check if the SHARED_DIRECTORY_2 variable is empty
-if [ ! -z "${SHARED_DIRECTORY_2}" ]; then
-  echo "Writing SHARED_DIRECTORY_2 to /etc/exports file"
-  echo "{{SHARED_DIRECTORY_2}} {{PERMITTED}}({{READ_ONLY}},{{SYNC}},no_subtree_check,no_auth_nlm,insecure,no_root_squash)" >> /etc/exports
-  /bin/sed -i "s@{{SHARED_DIRECTORY_2}}@${SHARED_DIRECTORY_2}@g" /etc/exports
-fi
+# Get mounts
+mounts="${@}"
 
-# Check if the PERMITTED variable is empty
-if [ -z "${PERMITTED}" ]; then
-  echo "The PERMITTED environment variable is unset or null, defaulting to '*'."
-  echo "This means any client can mount."
-  /bin/sed -i "s/{{PERMITTED}}/*/g" /etc/exports
-else
-  echo "The PERMITTED environment variable is set."
-  echo "The permitted clients are: ${PERMITTED}."
-  /bin/sed -i "s/{{PERMITTED}}/"${PERMITTED}"/g" /etc/exports
-fi
+for mnt in "${mounts[@]}"; do
+  src=$(echo $mnt | awk -F':' '{ print $1 }')
+  mkdir -p $src
+  echo "$src ${PERMITTED}($opts)" >> /etc/exports
+done
 
-# Check if the READ_ONLY variable is set (rather than a null string) using parameter expansion
-if [ -z ${READ_ONLY+y} ]; then
-  echo "The READ_ONLY environment variable is unset or null, defaulting to 'rw'."
-  echo "Clients have read/write access."
-  /bin/sed -i "s/{{READ_ONLY}}/rw/g" /etc/exports
-else
-  echo "The READ_ONLY environment variable is set."
-  echo "Clients will have read-only access."
-  /bin/sed -i "s/{{READ_ONLY}}/ro/g" /etc/exports
-fi
+## Check if the SHARED_DIRECTORY variable is empty
+#if [ -z "${SHARED_DIRECTORY}" ]; then
+#  echo "The SHARED_DIRECTORY environment variable is unset or null, exiting..."
+#  exit 1
+#else
+#  echo "Writing SHARED_DIRECTORY to /etc/exports file"
+#  /bin/sed -i "s@{{SHARED_DIRECTORY}}@${SHARED_DIRECTORY}@g" /etc/exports
+#fi
+#
+## This is here to demonsrate how multiple directories can be shared. You
+## would need a block like this for each extra share.
+## Any additional shares MUST be subdirectories of the root directory specified
+## by SHARED_DIRECTORY.
+#
+## Check if the SHARED_DIRECTORY_2 variable is empty
+#if [ ! -z "${SHARED_DIRECTORY_2}" ]; then
+#  echo "Writing SHARED_DIRECTORY_2 to /etc/exports file"
+#  echo "{{SHARED_DIRECTORY_2}} {{PERMITTED}}({{READ_ONLY}},{{SYNC}},no_subtree_check,no_auth_nlm,insecure,no_root_squash)" >> /etc/exports
+#  /bin/sed -i "s@{{SHARED_DIRECTORY_2}}@${SHARED_DIRECTORY_2}@g" /etc/exports
+#fi
 
-# Check if the SYNC variable is set (rather than a null string) using parameter expansion
-if [ -z "${SYNC+y}" ]; then
-  echo "The SYNC environment variable is unset or null, defaulting to 'async' mode".
-  echo "Writes will not be immediately written to disk."
-  /bin/sed -i "s/{{SYNC}}/async/g" /etc/exportsThese
-else
-  echo "The SYNC environment variable is set, using 'sync' mode".
-  echo "Writes will be immediately written to disk."
-  /bin/sed -i "s/{{SYNC}}/sync/g" /etc/exports
-fi
 
 # Partially set 'unofficial Bash Strict Mode' as described here: http://redsymbol.net/articles/unofficial-bash-strict-mode/
 # We don't set -e because the pidof command returns an exit code of 1 when the specified process is not found
-# We expect this at times and don't want the script to be terminated with it occurs
+# We expect this at times and don't want the script to be terminated if it occurs
 set -uo pipefail
 IFS=$'\n\t'
 
@@ -116,7 +130,7 @@ while true; do
     /usr/sbin/rpc.mountd --debug all --no-udp --no-nfs-version 2 --no-nfs-version 3
 # --exports-file /etc/exports
 
-    # Check if NFS is now running by recording it's PID (if it's not running $pid will be null):
+    # Check if NFS is now running by recording its PID (if it is not running $pid will be null):
     pid=`pidof rpc.mountd`
 
     # If $pid is null, startup failed; log the fact and sleep for 2s
@@ -137,7 +151,7 @@ done
 
 while true; do
 
-  # Check if NFS is STILL running by recording it's PID (if it's not running $pid will be null):
+  # Check if NFS is STILL running by recording its PID (if it is not running $pid will be null):
   pid=`pidof rpc.mountd`
   # If it is not, lets kill our PID1 process (this script) by breaking out of this while loop:
   # This ensures Docker observes the failure and handles it as necessary

--- a/nfsd.sh
+++ b/nfsd.sh
@@ -59,13 +59,13 @@ if [ -z "${NFS_OPTS}" ]; then
   DEFAULT_OPTS=fsid=0,no_subtree_check,no_auth_nlm,insecure,no_root_squash
   
   # Build opts string
-  opts=`echo "${SET_OPTS} ${DEFAULT_OPTS}" | tr -s ' ' | tr ' ' ','`
+  opts=${SET_OPTS},${DEFAULT_OPTS}
 else
 
   # Otherwise use NFS_OPTS directly
 
   # Build opts string
-  opts=`echo "${NFS_OPTS}" | tr -s ' ' | tr ' ' ','`
+  opts=${NFS_OPTS}
 fi;
 
 

--- a/nfsd.sh
+++ b/nfsd.sh
@@ -73,9 +73,7 @@ else
 fi;
 
 # Check if the SHARED_DIRECTORY variable is empty
-if [ -z "${SHARED_DIRECTORY}" ]; then
-  echo "The SHARED_DIRECTORY environment variable is unset or null, using new approach"
-else
+if [ ! -z "${SHARED_DIRECTORY}" ]; then
   echo "SHARED_DIRECTORY is set. Please use CMD instead"
   echo "Adding SHARED_DIRECTORY to CMD input"
   mounts[${#mounts[@]}]=$SHARED_DIRECTORY

--- a/nfsd.sh
+++ b/nfsd.sh
@@ -68,7 +68,14 @@ else
   opts=${NFS_OPTS}
 fi;
 
-
+# Check if the SHARED_DIRECTORY variable is empty
+if [ -z "${SHARED_DIRECTORY}" ]; then
+  echo "The SHARED_DIRECTORY environment variable is unset or null, using new approach"
+else
+  echo "SHARED_DIRECTORY is set. Please use CMD instead"
+  echo "Adding SHARED_DIRECTORY to CMD input"
+  mounts[${#mounts[@]}]=$SHARED_DIRECTORY
+fi
 
 # Get mounts
 mounts="${@}"
@@ -78,28 +85,6 @@ for mnt in "${mounts[@]}"; do
   mkdir -p $src
   echo "$src ${PERMITTED}($opts)" >> /etc/exports
 done
-
-## Check if the SHARED_DIRECTORY variable is empty
-#if [ -z "${SHARED_DIRECTORY}" ]; then
-#  echo "The SHARED_DIRECTORY environment variable is unset or null, exiting..."
-#  exit 1
-#else
-#  echo "Writing SHARED_DIRECTORY to /etc/exports file"
-#  /bin/sed -i "s@{{SHARED_DIRECTORY}}@${SHARED_DIRECTORY}@g" /etc/exports
-#fi
-#
-## This is here to demonsrate how multiple directories can be shared. You
-## would need a block like this for each extra share.
-## Any additional shares MUST be subdirectories of the root directory specified
-## by SHARED_DIRECTORY.
-#
-## Check if the SHARED_DIRECTORY_2 variable is empty
-#if [ ! -z "${SHARED_DIRECTORY_2}" ]; then
-#  echo "Writing SHARED_DIRECTORY_2 to /etc/exports file"
-#  echo "{{SHARED_DIRECTORY_2}} {{PERMITTED}}({{READ_ONLY}},{{SYNC}},no_subtree_check,no_auth_nlm,insecure,no_root_squash)" >> /etc/exports
-#  /bin/sed -i "s@{{SHARED_DIRECTORY_2}}@${SHARED_DIRECTORY_2}@g" /etc/exports
-#fi
-
 
 # Partially set 'unofficial Bash Strict Mode' as described here: http://redsymbol.net/articles/unofficial-bash-strict-mode/
 # We don't set -e because the pidof command returns an exit code of 1 when the specified process is not found

--- a/nfsd.sh
+++ b/nfsd.sh
@@ -19,7 +19,9 @@ stop()
   exit
 }
 
-# How much do we need these checks?
+# Get mounts
+mounts=( "${@}" )
+
 # Check if the PERMITTED variable is empty
 if [ -z "${PERMITTED}" ]; then
   echo "The PERMITTED environment variable is unset or null, defaulting to '*'."
@@ -55,6 +57,7 @@ fi
 # if NFS_OPTS is not set
 # then use legacy approach
 if [ -z "${NFS_OPTS}" ]; then
+  echo "NFS_OPTS has not been defined. Adding default parameters"
   # set default options from legacy approach
   DEFAULT_OPTS=fsid=0,no_subtree_check,no_auth_nlm,insecure,no_root_squash
   
@@ -63,6 +66,7 @@ if [ -z "${NFS_OPTS}" ]; then
 else
 
   # Otherwise use NFS_OPTS directly
+  echo "NFS_OPTS has been defined. Disregarding READ_ONLY,SYNC, and default parameters"
 
   # Build opts string
   opts=${NFS_OPTS}
@@ -77,10 +81,8 @@ else
   mounts[${#mounts[@]}]=$SHARED_DIRECTORY
 fi
 
-# Get mounts
-mounts="${@}"
-
 for mnt in "${mounts[@]}"; do
+  echo "Setting up exports for mount: $mnt"
   src=$(echo $mnt | awk -F':' '{ print $1 }')
   mkdir -p $src
   echo "$src ${PERMITTED}($opts)" >> /etc/exports


### PR DESCRIPTION
- Allows arbitrary number of `SHARED_DIRECTORY` inputs by using and parsing the `docker CMD`
- Allows arbitrary NFS options being set by using `NFS_OPTS` environment variable
- Tries valiantly to remain backwards compatible by:
    - Appending `SHARED_DIRECTORY` to the mount inputs
    - Using old patterns / defaults for `READ_ONLY` and `SYNC` if `NFS_OPTS` is not set

Would love to discuss if this is workable from your perspective and how committed you are to backwards compatibility. I think if backwards compatibility is not necessary, these deprecation warnings could be more forceful or you can simply bump the version and simplify the pattern by setting default `NFS_OPTS` and give users free reign to set their own options by overriding the environment variable.

NOTE: I submitted the PR to the `byebyeconfd` branch, since those changes looked desirable and these changes are related.

Related to #20 
Related to #22 