### PR TITLE
allow crossmounts and use subnet mask examples for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Adding `-e READ_ONLY=true` will cause the exports file to contain `ro` instead o
 
 Adding `-e SYNC=true` will cause the exports file to contain `sync` instead of `async`, enabling synchronous mode. Check the exports man page for more information: https://linux.die.net/man/5/exports.
 
-Adding `-e PERMITTED="10.11.99.*"` will permit only hosts with an IP address starting 10.11.99 to mount the file share.
+Adding `-e PERMITTED="10.11.99.0\/24"` will permit only hosts with an IP address starting 10.11.99 to mount the file share. The single backslash is used for escaping the slash dividing net address and netmask during the replacement via sed.
+
+Adding `-e CROSSMNT=yes` will allow to share mounts which are placed in `/some/where/fileshare`. This is especially needed when allowing more than only one IP.
 
 Due to the `fsid=0` parameter set in the **/etc/exports file**, there's no need to specify the folder name when mounting from a client. For example, this works fine even though the folder being mounted and shared is /nfsshare:
 

--- a/exports
+++ b/exports
@@ -1,1 +1,1 @@
-{{SHARED_DIRECTORY}} {{PERMITTED}}({{READ_ONLY}},fsid=0,{{SYNC}},no_subtree_check,no_auth_nlm,insecure,no_root_squash)
+{{SHARED_DIRECTORY}} {{PERMITTED}}({{READ_ONLY}},fsid=0,{{SYNC}},{{CROSSMNT}},no_subtree_check,no_auth_nlm,insecure,no_root_squash)

--- a/nfsd.sh
+++ b/nfsd.sh
@@ -81,7 +81,7 @@ if [ -z "${CROSSMNT+y}" ]; then
   /bin/sed -i "s/{{CROSSMNT}},//g" /etc/exports
 else
   echo "The CROSSMNT environment variable is set, allowing crossmounts."
-  /bin/sed -i "s/{{SYNC}}/crossmnt/g" /etc/exports
+  /bin/sed -i "s/{{CROSSMNT}}/crossmnt/g" /etc/exports
 fi
 
 # Partially set 'unofficial Bash Strict Mode' as described here: http://redsymbol.net/articles/unofficial-bash-strict-mode/

--- a/nfsd.sh
+++ b/nfsd.sh
@@ -74,6 +74,16 @@ else
   /bin/sed -i "s/{{SYNC}}/sync/g" /etc/exports
 fi
 
+# Check if the CROSSMNT variable is set (rather than a null string) using parameter expansion
+if [ -z "${CROSSMNT+y}" ]; then
+  echo "The CROSSMNT environment variable is unset or null, so do not allow crossmounts."
+  echo "Mounts in shares will appear empty"
+  /bin/sed -i "s/{{CROSSMNT}},//g" /etc/exports
+else
+  echo "The CROSSMNT environment variable is set, allowing crossmounts."
+  /bin/sed -i "s/{{SYNC}}/crossmnt/g" /etc/exports
+fi
+
 # Partially set 'unofficial Bash Strict Mode' as described here: http://redsymbol.net/articles/unofficial-bash-strict-mode/
 # We don't set -e because the pidof command returns an exit code of 1 when the specified process is not found
 # We expect this at times and don't want the script to be terminated when it occurs


### PR DESCRIPTION
Just ran into two issues and decided to fix them.

First thing was that setting the IPs via * would not work, so I decided to stick to the netmask example. Imho this is also much more readable.

Second I took your advice by _assembling_ my nfs share by mounting different folders. This didn't work at first - turns out when you allow a whole network, remember to set this option, otherwise you see only empty directories.

Hope this is useful for you :)