### PR TITLE
Need 'crossmnt' flag to allow volumes inside exported dir

### DIFF
--- a/exports
+++ b/exports
@@ -1,1 +1,1 @@
-{{SHARED_DIRECTORY}} {{PERMITTED}}({{READ_ONLY}},fsid=0,{{SYNC}},no_subtree_check,no_auth_nlm,insecure,no_root_squash)
+{{SHARED_DIRECTORY}} {{PERMITTED}}({{READ_ONLY}},fsid=0,{{SYNC}},no_subtree_check,no_auth_nlm,insecure,no_root_squash,crossmnt)


### PR DESCRIPTION
Hello,

to support docker volumes inside exported directory, there is necessary to add `crossmnt` flag.

Example `docker-compose.yml`
```yml
version: '3.3'

services:
 nfs:
  image: itsthenetwork/nfs-server-alpine:latest
  privileged: true
  volumes:
    - ./export:/export
    - type: volume
      source: somevolume
      target: /export/somevolume
  environment:
    - SHARED_DIRECTORY=/export

volumes:
  somevolume: ~
```